### PR TITLE
fix signal and invalid AppType on legacy gsm

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -3261,10 +3261,13 @@ public class RIL extends BaseCommands implements CommandsInterface {
             numApplications = IccCardStatus.CARD_MAX_APPS;
         }
         cardStatus.mApplications = new IccCardApplicationStatus[numApplications];
-
+        oldRil = needsOldRilFeature("apptypesim");
+        
         for (int i = 0 ; i < numApplications ; i++) {
             appStatus = new IccCardApplicationStatus();
             appStatus.app_type       = appStatus.AppTypeFromRILInt(p.readInt());
+            // Seems the simplest way so we dont mess up the parcel
+            if (oldRil) appStatus.app_type = appStatus.AppTypeFromRILInt(1);
             appStatus.app_state      = appStatus.AppStateFromRILInt(p.readInt());
             appStatus.perso_substate = appStatus.PersoSubstateFromRILInt(p.readInt());
             appStatus.aid            = p.readString();


### PR DESCRIPTION
http://review.evervolv.com/#/c/8552/   and http://review.evervolv.com/#/c/8551/

Tytung was the first which found this patches. And checked that only this 2 patches needed to fix gsm.

http://androidforum.tytung.com/nexushd2-jellybean-cm10-2-t78-360.html#p2764

post: 377
